### PR TITLE
feat: Add TS typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "unpkg": "dist/vue-slim-tabs.js",
   "jsdelivr": "dist/vue-slim-tabs.js",
   "cdn": "dist/vue-slim-tabs.js",
+  "types": "types/vue-slim-tabs.d.ts",
   "poi": {
     "entry": "example/index.js",
     "output": {
@@ -19,7 +20,8 @@
   },
   "files": [
     "dist",
-    "themes"
+    "themes",
+    "types"
   ],
   "scripts": {
     "test": "echo 'no tests!' && npm run lint",

--- a/types/vue-slim-tabs.d.ts
+++ b/types/vue-slim-tabs.d.ts
@@ -5,8 +5,8 @@ export const Tab: TabConstructor;
 export const install: PluginFunction<{}>;
 
 export interface TabsProps {
-  defaultIndex: number;
-  onSelect: (val: any) => void;
+  defaultIndex?: number;
+  onSelect?: (val: any) => void;
 }
 
 export interface TabsData {
@@ -18,9 +18,9 @@ export interface TabsMethods {
 }
 
 export interface TabProps {
-  title: string;
-  titleSlot: string;
-  disabled: boolean;
+  title?: string;
+  titleSlot?: string;
+  disabled?: boolean;
 }
 
 export interface TabsConstructor extends VueConstructor {

--- a/types/vue-slim-tabs.d.ts
+++ b/types/vue-slim-tabs.d.ts
@@ -14,7 +14,7 @@ export interface TabsData {
 }
 
 export interface TabsMethods {
-  switchTable: (e: Event, index: number, isDisabled: boolean) => void;
+  switchTab: (e: Event, index: number, isDisabled: boolean) => void;
 }
 
 export interface TabProps {

--- a/types/vue-slim-tabs.d.ts
+++ b/types/vue-slim-tabs.d.ts
@@ -1,0 +1,34 @@
+import { PluginFunction, VueConstructor } from 'vue';
+
+export const Tabs: TabsConstructor;
+export const Tab: TabConstructor;
+export const install: PluginFunction<{}>;
+
+export interface TabsProps {
+  defaultIndex: number;
+  onSelect: (val: any) => void;
+}
+
+export interface TabsData {
+  selectedIndex: number;
+}
+
+export interface TabsMethods {
+  switchTable: (e: Event, index: number, isDisabled: boolean) => void;
+}
+
+export interface TabProps {
+  title: string;
+  titleSlot: string;
+  disabled: boolean;
+}
+
+export interface TabsConstructor extends VueConstructor {
+  props: TabsProps;
+  data: () => TabsData;
+  methods: TabsMethods;
+}
+
+export interface TabConstructor extends VueConstructor {
+  props: TabProps;
+}


### PR DESCRIPTION
Added definitions file in `types` folder to fix #25

With this PR the module can be imported in TS
```vue
<script lang="ts">
  import { Tabs, Tab } from 'vue-slim-tabs';

  export default {
    components: {
      Tabs, Tab
    }
  }
</script>
```
, also as a plugin:
```ts
import * as Tabs from 'vue-slim-tabs';

Vue.use(Tabs);
```


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#25: Provide types for TypeScript](https://issuehunt.io/repos/93767474/issues/25)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->