### PR TITLE
Fix onSelect usage

### DIFF
--- a/example/App.vue
+++ b/example/App.vue
@@ -11,9 +11,9 @@
       > 1.3 kB minified (418 bytes gzipped).
     </p>
     <label class="enable-angular">
-      <input type="checkbox" v-model="angular"> Enable augular tab
+      <input type="checkbox" v-model="angular"> Enable angular tab
     </label>
-    <tabs class="my-tabs">
+    <tabs class="my-tabs" :onSelect="handleTabSelected">
 
       <template slot="react">React</template>
 
@@ -46,6 +46,7 @@
       </tab>
 
     </tabs>
+    <WithJSX />
   </div>
 </template>
 
@@ -55,6 +56,7 @@ import {
   Tabs,
   Tab
 } from '../src'
+import WithJSX from './WithJSX'
 
 export default {
   data() {
@@ -66,7 +68,14 @@ export default {
   components: {
     Tabs,
     Tab,
+    WithJSX,
     Github: GitHub
+  },
+
+  methods: {
+    handleTabSelected(e, index) {
+      console.log(e, index);
+    }
   }
 }
 </script>

--- a/example/WithJSX.js
+++ b/example/WithJSX.js
@@ -1,0 +1,36 @@
+import { Tabs, Tab } from '../src';
+
+export default {
+  name: 'WithJSXExample',
+  data() {
+    return { currentTabIndex: 0 };
+  },
+  methods: {
+    handleTabSelected(e, index) {
+      console.log(e, index);
+      this.currentTabIndex = index;
+    }
+  },
+  render() {
+    const secondTabTitle = <span>Second tab <em>(click me!)</em></span>
+
+    return (
+      <div>
+        <h2>Example with JSX</h2>
+        <h3>
+          Selected tab index is: {this.currentTabIndex}
+        </h3>
+        <Tabs onSelect={this.handleTabSelected}>
+          <Tab title="First tab">
+            <p>JSX is awesome!</p>
+            <p>When you change tab, displayed index ⬆️ should update.</p>
+          </Tab>
+          <Tab title={secondTabTitle}>
+            <p>Well, the index displayed should be 1, now.</p>
+            <p>Oh, and check the console, it must have logged a <code>MouseEvent</code>.</p>
+          </Tab>
+        </Tabs>
+      </div>
+    );
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,13 @@ export const Tabs = {
   },
   methods: {
     switchTab(e, index, isDisabled) {
-      if (!isDisabled) {
-        this.selectedIndex = index;
-        this.onSelect && this.onSelect(e, index);
+      if (isDisabled || this.selectedIndex === index) {
+        return;
       }
+
+      this.selectedIndex = index;
+      this.onSelect && this.onSelect(e, index);
+      this.$emit("select", e, index);
     }
   },
   render() {


### PR DESCRIPTION
This PR is fixing all aspects of #40:

- emit a `select` custom event so that we can use JSX with `onSelect` prop,
- keep the legacy way of passing the `onSelect` function prop as a callback (for retro-compatibility),
- avoid multiple executions of the `onSelect` callback (and "select" event) when clicking on the same tab again,
- add an example using JSX, with `onSelect` event handling,
- add an example of `onSelect` callback in existing example which use template.

I hope you'll approve this soon!