### PR TITLE
feat: allow tab to be selected by URL's query param

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,19 @@ export const Tabs = {
       type: Function
     }
   },
+  mounted() {
+    if (this.$route.query.tab) {
+      const tabs = this.$slots.default
+        .filter(component => component.componentOptions)
+        .map(component => component.componentOptions.propsData.title);
+
+      const index = tabs.findIndex(title => title === this.$route.query.tab);
+
+      if (index) {
+        this.switchTab(undefined, index);
+      }
+    }
+  },
   data() {
     return {
       selectedIndex: this.defaultIndex
@@ -19,6 +32,24 @@ export const Tabs = {
       if (!isDisabled) {
         this.selectedIndex = index;
         this.onSelect && this.onSelect(e, index);
+
+        const tabs = this.$slots.default
+          .filter(component => {
+            return component.componentOptions;
+          })
+          .map(component => {
+            return component.componentOptions.propsData.title;
+          });
+
+        const query = {};
+        for (const q of new URL(window.location).searchParams) {
+          query[q[0]] = q[1];
+        }
+
+        this.$router.push({
+          path: new URL(window.location).pathname,
+          query: { ...query, tab: tabs[index] }
+        });
       }
     }
   },


### PR DESCRIPTION
Hello,

I add the feature to allow tab to be select a tab by a query parameter at the mount of the component.

- When you click on a tab, the tab is written on the url.
- When you mount the component, if a query param `tab=foo` is present, the tab `foo` will be automatically selected.

Tell me if you have any feedback.
Thank you for your work and have a nice day!
